### PR TITLE
Indiscriminately close the events channel on task error

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ To integrate the package:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/stairtree/StructuredWebSocketClient.git", from: "0.1.0"),
+    .package(url: "https://github.com/stairtree/StructuredWebSocketClient.git", from: "0.2.0"),
 ]
 ```

--- a/Sources/StructuredWebSocketClient/URLSession+MessageTransport.swift
+++ b/Sources/StructuredWebSocketClient/URLSession+MessageTransport.swift
@@ -154,9 +154,7 @@ public actor URLSessionWebSocketTransport: MessageTransport, SimpleURLSessionTas
         await self.events.send(.failure(nsError))
         // If the task is already closed, we need to call onClose, as that is
         // the only way the events channel is finished.
-        if self.wsTask.closeCode != .invalid {
-            await self.onClose(closeCode: .abnormalClosure, reason: Data(reason.utf8))
-        }
+        await self.onClose(closeCode: .abnormalClosure, reason: Data(reason.utf8))
     }
     
     private func readNextMessage(_ number: Int) async {


### PR DESCRIPTION
If the task never successfully opens a socket, we have a closeCode of .invalid and yet we still need to immidately end the events channel.