### PR TITLE
Make URLSessionWebSocketTransport init synchronous

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           - 'watchOS Simulator'
         include:
           - platform: 'macOS'
-            destination: 'arch=x86_64'
+            destination: 'arch=arm64'
           - platform: 'iOS Simulator'
             destination: 'OS=latest,name=iPhone 15 Pro'
           - platform: 'tvOS Simulator'
@@ -32,7 +32,7 @@ jobs:
           - platform: 'watchOS Simulator'
             destination: 'OS=latest,name=Apple Watch Series 9 (45mm)'
     name: ${{ matrix.platform }} Tests
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -95,40 +95,3 @@ jobs:
 #         with:
 #           cc_token: ${{ secrets.CODECOV_TOKEN }}
 #           cc_verbose: true
-
-  codeql:
-    if: ${{ !(github.event.pull_request.draft || false) }}
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-    container:
-      image: swift:5.9-jammy
-    permissions: { actions: write, contents: read, security-events: write }
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Mark repo safe
-        run: |
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with: { languages: swift }
-      - name: Perform build
-        run: swift build
-      - name: Run CodeQL analyze
-        uses: github/codeql-action/analyze@v3
-
-  dependency-graph:
-    if: ${{ github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    container: swift:jammy
-    permissions:
-      contents: write
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up dependencies
-        run: |
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-          apt-get update && apt-get install -y curl
-      - name: Submit dependency graph
-        uses: vapor-community/swift-dependency-submission@v0.1

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the StructuredWebSocketClient open source project

--- a/Sources/StructuredWebSocketClient/URLSession+DelegateHelpers.swift
+++ b/Sources/StructuredWebSocketClient/URLSession+DelegateHelpers.swift
@@ -50,11 +50,20 @@ extension SimpleURLSessionTaskDelegate {
 /// which is a reference type, to ensure that an explicitly weak reference may be taken.
 final class URLSessionDelegateAdapter<D: SimpleURLSessionTaskDelegate & AnyObject>: NSObject, URLSessionWebSocketDelegate {
     private weak var realDelegate: D?
-
+    
     init(adapting realDelegate: D) {
         self.realDelegate = realDelegate
     }
-
+    
+    /// Allows initializing without providing the real delegate immediately
+    ///
+    /// This is helpful in non-isolated actor initializers, where self is not available yet.
+    override init() {}
+    
+    func setDelegate(_ realDelegate: D) {
+        self.realDelegate = realDelegate
+    }
+    
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?) {
         self.realDelegate?.urlSession(session, task: task, didCompleteWithError: error)
     }

--- a/Sources/StructuredWebSocketClient/URLSession+MessageTransport.swift
+++ b/Sources/StructuredWebSocketClient/URLSession+MessageTransport.swift
@@ -73,13 +73,14 @@ public actor URLSessionWebSocketTransport: MessageTransport, SimpleURLSessionTas
     private let events: AsyncChannel<WebSocketEvent> = .init()
     private var isAlreadyClosed = false
     
-    public init(request: URLRequest, urlSession: URLSession = .shared, logger: Logger? = nil) async {
+    public init(request: URLRequest, urlSession: URLSession = .shared, logger: Logger? = nil) {
         self.logger = logger ?? .init(label: "URLSessionWebSocketTransport")
 
         self.delegateQueue = urlSession.delegateQueue
-        self.delegateHandler = URLSessionDelegateAdapter(adapting: self)
+        self.delegateHandler = URLSessionDelegateAdapter() // self is not yet available in non-isolated init
         let urlSession = URLSession(configuration: urlSession.configuration, delegate: self.delegateHandler, delegateQueue: urlSession.delegateQueue)
         self.wsTask.task = urlSession.webSocketTask(with: request)
+        self.delegateHandler?.setDelegate(self) // so we have to set the delegate here
     }
     
     public func send(_ message: URLSessionWebSocketTask.Message) async throws {

--- a/Tests/StructuredWebSocketClientTests/WebSocketClientTests.swift
+++ b/Tests/StructuredWebSocketClientTests/WebSocketClientTests.swift
@@ -68,7 +68,7 @@ final class WebSocketClientTests: XCTestCase {
 
         // Postman's echo server
         let request = URLRequest(url: .init(string: "wss://ws.postman-echo.com/raw")!)
-        let client = await WebSocketClient(inboundMiddleware: nil, outboundMiddleware: nil, transport: URLSessionWebSocketTransport(request: request), logger: logger)
+        let client = WebSocketClient(inboundMiddleware: nil, outboundMiddleware: nil, transport: URLSessionWebSocketTransport(request: request), logger: logger)
         let outMsg = "Hi there"
         let expectation = XCTestExpectation(description: "message received")
         


### PR DESCRIPTION
We want to access nonisolated self, which is only possible since swift-tools-version 5.10 and https://github.com/apple/swift-evolution/blob/main/proposals/0327-actor-initializers.md